### PR TITLE
Add support for the Olimex ESP32 Gateway

### DIFF
--- a/data/firmware/firmware.json
+++ b/data/firmware/firmware.json
@@ -782,6 +782,41 @@
                 "size": "0x50000",
                 "offset": "0x3B0000"
             }
+        },
+        {
+            "name": "Olimex ESP32 Gateway",
+            "description": "Olimex board with ESP32, Ethernet, SD slot, and GPIO headers",
+            "chip": "esp32",
+            "appbin": "esp32/olimex_esp32_gw-app.bin",
+            "esptool": {
+                "baudrate": "460800",
+                "options": "--before default_reset --after hard_reset",
+                "flashcmd": "write_flash -z"
+            },
+            "binfiles": [
+                {
+                    "name": "esp32/olimex_esp32_gw-bootloader.bin",
+                    "offset": "0x1000"
+                },
+                {
+                    "name": "esp32/olimex_esp32_gw-partitions.bin",
+                    "offset": "0x8000"
+                },
+                {
+                    "name": "esp32/boot_app0.bin",
+                    "offset": "0xe000"
+                },
+                {
+                    "name": "esp32/olimex_esp32_gw-app.bin",
+                    "offset": "0x10000"
+                }
+            ],
+            "filesystem": {
+                "page": "256",
+                "block": "4096",
+                "size": "0x50000",
+                "offset": "0x3B0000"
+            }
         }
     ]
 }


### PR DESCRIPTION
Complement to [ESPixelStick PR#583](https://github.com/forkineye/ESPixelStick/pull/583)

Adds the [Olimex ESP32 Gateway](https://www.olimex.com/Products/IoT/ESP32/ESP32-GATEWAY/open-source-hardware) as a flash target.